### PR TITLE
remove blog from the nav bar; change News to direct to Twitter

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -118,17 +118,16 @@
             </a>
           </li>
           <li class="nav-item">
-            <a {% if current[1] == 'news.html' %} class="nav-link active" 
-               {% else %} class="nav-link" {% endif %} href="/news.html">
+            <a class="nav-link" href="https://x.com/LabsGlobus">
               News
             </a>
           </li>
-          <li class="nav-item">
+          <!-- <li class="nav-item">
             <a {% if current[1] == 'blog.html' %} class="nav-link active" 
                {% else %} class="nav-link" {% endif %} href="/blog.html">
               Blog
             </a>
-          </li>
+          </li> -->
           <li class="nav-item">
             <a {% if current[1] == 'publications.html' %} class="nav-link active" 
                {% else %} class="nav-link" {% endif %} 


### PR DESCRIPTION
Two simple changes in the _layouts/default.html files to avoid public people seeing old news.